### PR TITLE
OnCollisionStay used to avoid weird bugs...

### DIFF
--- a/Assets/Scripts/gridScripts/gridPiece.cs
+++ b/Assets/Scripts/gridScripts/gridPiece.cs
@@ -46,13 +46,17 @@ public class gridPiece : MonoBehaviour {
 		notifyGrid(false);
 	}
 
-	/*
+
 	void OnCollisionStay(Collision collision) {
+		/*
 		Debug.Log("Grid piece at (" + 
 		          transform.position.x + ", " + transform.position.y 
 		          + ") is Colliding with " +
 		          collision.transform.name);
+		*/
+		setIsOccupied(true);
+		notifyGrid(true);
 	}
-	*/
+
 
 }


### PR DESCRIPTION
however, this probably slows the game a bit since it is inefficient.  The strange bugs happen because the tetris pieces are not always moved 'physically' and the grid is not upadated becasue the exit-collision is not detected.
